### PR TITLE
Use Node v14 instead of LTS

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -81,8 +81,12 @@ else
     echo "nvm version ${nvm_ver} is installed"
 fi
 
-LTS_VER=$(nvm version-remote --lts)
-nvm use ${LTS_VER} &> /dev/null
+# Avoid problems with Node versions > 14
+# LTS_VER=$(nvm version-remote --lts)
+# nvm use ${LTS_VER} &> /dev/null
+LTS_VER=14
+nvm install ${LTS_VER} &> /dev/null
+
 if (($? != 0)); then
     echo "Installing node version ${LTS_VER}"
     nvm install --lts &> /dev/null


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Install and use Node v14 rather than LTS (v16+) which currently causes problems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
